### PR TITLE
Add TIO to mirrors list

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@ redirect_from: "/Mathics/"
 
       <ul id="mirrors">
       <li><a href="https://mathics.angusgriffith.com">https://mathics.angusgriffith.com</a></li>
+      <li><a href="https://tio.run/#mathics">https://tio.run/#mathics</a></li>
       </ul>
 
       <h2>


### PR DESCRIPTION
TIO (tryitonline.net) hosts interpreters for many languages, including Mathics. I propose it be added as a mirror.